### PR TITLE
Force TLS 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+/.vs

--- a/src/ZendeskTicketExporter.Console/Program.cs
+++ b/src/ZendeskTicketExporter.Console/Program.cs
@@ -43,6 +43,8 @@ namespace ZendeskTicketExporter.Console
     {
         private static void Main(string[] args)
         {
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12 | System.Net.SecurityProtocolType.Tls11 | System.Net.SecurityProtocolType.Tls;
+
             var options = new Options();
             if (Parser.Default.ParseArguments(args, options))
             {


### PR DESCRIPTION
Resolves this error:

System.Net.WebException: The request was aborted: Could not create SSL/TLS secure channel.  

which I was getting when running from the original source.

(May not be the most elegant solution!)